### PR TITLE
Configuration edits based on UCSF Wynton tests

### DIFF
--- a/mappertrac/subscripts/utilities.py
+++ b/mappertrac/subscripts/utilities.py
@@ -63,6 +63,8 @@ def run(command, params=None, ignore_errors=False, print_output=True, print_time
         command = (f'singularity exec {"--nv" if use_gpu else ""} ' +
             f'--cleanenv ' +
             f'--home /fake_home_dir ' +
+            f'-B /opt/sge ' +
+            f'-B /wynton/home/mukherjee/shared/mappertrac/license.txt:/opt/freesurfer/license.txt' +
             f'-B {work_dir}:/mappertrac {container} ' +
             f'sh -c "{command}"')
         print(command)


### PR DESCRIPTION
This pull request involves 3 commits to cli.py, utilities.py, and s1_freesurfer.py. For cli.py, help messages for inputs were updated. Configuration for grid engine is updated. For utilities.py, wynton-specific mounting flags were added but ideally these changes should be conditioned for SGE platforms only. For s1, ncores was modified for wynton in a way that the requested number of cores at parsl qsub would be consistent with freesurfer recon-all command. Also, features of detection of existing DTI parameter maps and skipping dtifit were added. The code section flag "### recon-all ###" location was moved to be after dtifit. 