### PR TITLE
Added new container recipe and improved s1 preprocessing

### DIFF
--- a/mappertrac/data/container/recipe_mappertrac.def
+++ b/mappertrac/data/container/recipe_mappertrac.def
@@ -1,0 +1,119 @@
+Bootstrap: docker
+From: ubuntu:20.04
+
+%labels
+  Version v1.0
+
+%files
+  license_freesurfer.txt /opt/license_freesurfer.txt
+
+%post
+  mkdir /mappertrac
+
+  # Install dependencies
+  apt-get -y update
+  apt-get install -y apt-transport-https ca-certificates
+  apt-get install -y software-properties-common
+  add-apt-repository -y universe
+  add-apt-repository -y ppa:deadsnakes/ppa
+  sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+  apt-get update && apt-get upgrade -y && apt-get install -y \
+    curl \
+    bzip2 \
+    build-essential \
+    libgl1-mesa-glx \
+    libgl1-mesa-dev \
+    wget \
+    tcsh \
+    libtool \
+    unzip \
+    kmod \
+    initramfs-tools \
+    locales \
+    vim-tiny \
+    dkms \
+    mricron \
+    debhelper \
+    dh-autoreconf \
+    python \
+    pkg-config
+
+  apt install bash-completion
+  
+  rm /bin/sh
+  ln -s /bin/bash /bin/sh
+
+  # Install older C compiler (gcc8) because Ubuntu 20.04 has gcc9 default but CUDA10 only supports up to gcc8
+  #apt -y install gcc-8 g++-8
+  #update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 8
+  #update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 8
+  #update-alternatives --config gcc
+  #update-alternatives --config g++  
+
+  # Install Python 3.10
+  apt-get -y install python3.10
+  
+  # Install FSL 6.0.6: from this release, eddy_gpu, bedpostx_gpu, and probtrackx_gpu are integrated and need NO additional installation. 
+  FSL6=https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py
+  FSL6_RUN=$(basename $FSL6)
+  wget --no-check-certificate $FSL6
+  python $FSL6_RUN -d /usr/local/fsl  
+
+  # Install FSL Registration 4D extension for FLIRT and FNIRT
+  wget --no-check-certificate https://www.nitrc.org/frs/download.php/5308/registrationFiles.zip
+  unzip -o -d /usr/local/fsl registrationFiles.zip
+
+  # Install FreeSurfer
+  curl -O https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.3.2/freesurfer-linux-ubuntu20_amd64-7.3.2.tar.gz
+  tar -C /opt -xzvf freesurfer-linux-ubuntu20_amd64-7.3.2.tar.gz
+  mv /opt/license_freesurfer.txt /opt/freesurfer/license.txt
+  chmod a+r /opt/freesurfer/license.txt 
+
+
+  # Install MRTrix
+  apt-get -y install libeigen3-dev zlib1g-dev libqt5opengl5-dev libqt5svg5-dev libgl1-mesa-dev libfftw3-dev libtiff5-dev libpng-dev
+  wget --no-check-certificate https://github.com/MRtrix3/mrtrix3/archive/994498557037c9e4f7ba67f255820ef84ea899d9.zip
+  unzip -o -d /opt 994498557037c9e4f7ba67f255820ef84ea899d9.zip
+  cd /opt/mrtrix3-994498557037c9e4f7ba67f255820ef84ea899d9
+  python3 ./configure -nogui -openmp
+  python3 ./build
+  cd $MAIN_DIR
+
+  # Cleanup
+  apt-get -y clean
+  rm /fslinstaller.py /*.zip /*.tar.gz 
+
+%environment
+  export FSLDIR=/usr/local/fsl
+  FSL_DIR=$FSLDIR
+  FSLOUTPUTTYPE=NIFTI_GZ
+  FSLMULTIFILEQUIT=TRUE
+  FSLTCLSH=${FSLDIR}/bin/fsltclsh
+  FSLWISH=${FSLDIR}/bin/fslwish
+  FSLGECUDAQ="gpu.q"
+  FSL_BIN=${FSLDIR}/bin
+  FS_OVERRIDE=0
+  COMPILE_GPU=1
+  export FSL_DIR FSLOUTPUTTYPE FSLMULTIFILEQUIT FSLTCLSH FSLWISH FSLGECUDAQ FSL_BIN FS_OVERRIDE COMPILE_GPU
+
+  export FREESURFER_HOME=/opt/freesurfer
+  LOCAL_DIR=${FREESURFER_HOME}/local
+  PERL5LIB=${FREESURFER_HOME}/mni/share/perl5
+  FSFAST_HOME=${FREESURFER_HOME}/fsfast
+  FMRI_ANALYSIS_DIR=${FREESURFER_HOME}/fsfast
+  FSF_OUTPUT_FORMAT="nii.gz"
+  MNI_DIR=${FREESURFER_HOME}/mni
+  MNI_DATAPATH=${FREESURFER_HOME}/mni/data
+  MNI_PERL5LIB=${FREESURFER_HOME}/mni/share/perl5
+  MINC_BIN_DIR=${FREESURFER_HOME}/mni/bin
+  MINC_LIB_DIR=${FREESURFER_HOME}/mni/lib
+  SUBJECTS_DIR=/mappertrac
+  FUNCTIONALS_DIR=${FREESURFER_HOME}/sessions
+
+  export MRTRIX_DIR=/opt/mrtrix3-994498557037c9e4f7ba67f255820ef84ea899d9
+
+  export LOCAL_DIR PERL5LIB FSFAST_HOME FMRI_ANALYSIS_DIR FSF_OUTPUT_FORMAT MNI_DIR MNI_DATAPATH MNI_PERL5LIB MINC_BIN_DIR MINC_LIB_DIR SUBJECTS_DIR FUNCTIONALS_DIR
+
+  export PATH="${FSLDIR}/bin:/usr/local/cuda/bin:${FREESURFER_HOME}/bin:${MNI_DIR}/bin:${MRTRIX_DIR}/bin:$PATH"
+  export LD_LIBRARY_PATH="${FSLDIR}/lib:/usr/local/cuda/lib64:${FREESURFER_HOME}/lib:${MNI_DIR}/lib:${MRTRIX_DIR}/lib:$LD_LIBRARY_PATH"
+  export OS=LINUX

--- a/mappertrac/subscripts/s1_freesurfer.py
+++ b/mappertrac/subscripts/s1_freesurfer.py
@@ -93,13 +93,13 @@ Arguments:
 
     # Write reorganized bvals
     work_bval_reorg = join(sdir, 'bvals_reorg')
-    bval_txt_reorg = open(work_bval_reorg, 'w')
-    bval_list_reorg = [b for idx, b in enumerate(bval_list) if b != '0']
-    bval_txt_reorg.write('0')
-    for i in range(len(bval_list_reorg)):
-      bval_txt_reorg.write(' ')
-      bval_txt_reorg.write(bval_list_reorg[i])  
-    bval_txt_reorg.write('\n')
+    with open(work_bval_reorg, 'w') as bval_txt_reorg:
+      bval_list_reorg = [b for idx, b in enumerate(bval_list) if b != '0']
+      bval_txt_reorg.write('0')
+      for i in range(len(bval_list_reorg)):
+        bval_txt_reorg.write(' ')
+        bval_txt_reorg.write(bval_list_reorg[i])  
+      bval_txt_reorg.write('\n')
 
     # Write reorganized bvecs
     bvec_txt = open(work_bvec, 'r')
@@ -107,14 +107,14 @@ Arguments:
     bvec_list_reorg = [b for idx, b in enumerate(bvec_list) if b != '0']
     
     work_bvec_reorg = join(sdir, 'bvecs_reorg')
-    bvec_txt_reorg = open(work_bvec_reorg, 'w')
-    bvec_txt_reorg.write('0')
-    nvols_diffusion = int(len(bvec_list_reorg)/3)
-    bvec_line_breaks = [nvols_diffusion, nvols_diffusion * 2]
-    for i in range(len(bvec_list_reorg)):
-      bvec_txt_reorg.write('\n' + '0 ') if i in bvec_line_breaks else bvec_txt_reorg.write(' ')
-      bvec_txt_reorg.write(bvec_list_reorg[i])
-    bvec_txt_reorg.write('\n')
+    with open(work_bvec_reorg, 'w') as bvec_txt_reorg:
+      bvec_txt_reorg.write('0')
+      nvols_diffusion = int(len(bvec_list_reorg)/3)
+      bvec_line_breaks = [nvols_diffusion, nvols_diffusion * 2]
+      for i in range(len(bvec_list_reorg)):
+        bvec_txt_reorg.write('\n' + '0 ') if i in bvec_line_breaks else bvec_txt_reorg.write(' ')
+        bvec_txt_reorg.write(bvec_list_reorg[i])
+      bvec_txt_reorg.write('\n')
 
     write(stdout, f'Finished reorganizing the dwi image and the bvec, bval files.')
 
@@ -180,6 +180,8 @@ Arguments:
         write(stdout, "DTI parameter maps already exist. Skipping DTI fit. ")
     else:
         if exists(bet_mask):
+            run(f'cat -e {work_bvec_reorg}', params)
+            run(f'cat -e {work_bval_reorg}', params) 
             run(f'dtifit --verbose -k {data_eddy} -o {dti_params} -m {bet_mask} -r {work_bvec_reorg} -b {work_bval_reorg}', params)
             run(f'fslmaths {dti_L1} -add {dti_L2} -add {dti_L3} -div 3 {dti_MD}', params)
             run(f'fslmaths {dti_L2} -add {dti_L3} -div 2 {dti_RD}', params)


### PR DESCRIPTION
In this contribution, a new container recipe is included that has Ubuntu20.04, python3.10, FSL 6.0.6 (with all gpu functions compatible with CUDA 10.2), CUDA toolkit that FSL6.0.6 depends on, FreeSurfer, and MRTrix3. This recipe includes  exporting he bin and lib paths to system variables PATH and LD_LIBRARY_PATH, so users of the built containers would not need to export additionally when launching the container.

Also in this contribution, subscript s1_freesurfer has been updated with the capability of processing diffusion MRI input images with arbitrary order of b-values. Previous s1 version assumed the input image to have the 1st volume be b0 and the following be diffusion volumes. The new version detects b0 volume index (indices), compute their average, and reorganize the input image to have b0_avg as the first volume followed by diffusion volumes. The new version also creates reorganized bval and bvec files. 