### PR TITLE
Fix bvec reorganization in s1

### DIFF
--- a/mappertrac/subscripts/s1_freesurfer.py
+++ b/mappertrac/subscripts/s1_freesurfer.py
@@ -104,7 +104,10 @@ Arguments:
     # Write reorganized bvecs
     bvec_txt = open(work_bvec, 'r')
     bvec_list = bvec_txt.read().split()
-    bvec_list_reorg = [b for idx, b in enumerate(bvec_list) if b != '0']
+    b0_idx_for_bvec = [b0_idx[0]]
+    b0_idx_for_bvec.append(b0_idx_for_bvec[0] + len(bval_list))
+    b0_idx_for_bvec.append(b0_idx_for_bvec[1] + len(bval_list))
+    bvec_list_reorg = [b for idx, b in enumerate(bvec_list) if idx not in b0_idx_for_bvec]
     
     work_bvec_reorg = join(sdir, 'bvecs_reorg')
     with open(work_bvec_reorg, 'w') as bvec_txt_reorg:


### PR DESCRIPTION
The issue was caught during WUSTL testing: bvec_list_reorg in previous version would remove all 0 values in each line of bvec, even if some of the 0s belong to a non-zero vector. Now bvec_list_reorg can keep 0 values that don't belong to b0 volumes.