### PR TITLE
Fixed bvec reorg inconsistent to bval reorg

### DIFF
--- a/mappertrac/subscripts/s1_freesurfer.py
+++ b/mappertrac/subscripts/s1_freesurfer.py
@@ -104,9 +104,7 @@ Arguments:
     # Write reorganized bvecs
     bvec_txt = open(work_bvec, 'r')
     bvec_list = bvec_txt.read().split()
-    b0_idx_for_bvec = [b0_idx[0]]
-    b0_idx_for_bvec.append(b0_idx_for_bvec[0] + len(bval_list))
-    b0_idx_for_bvec.append(b0_idx_for_bvec[1] + len(bval_list))
+    b0_idx_for_bvec = b0_idx + [i + len(bval_list) for i in b0_idx] + [i + 2 * len(bval_list) for i in b0_idx]
     bvec_list_reorg = [b for idx, b in enumerate(bvec_list) if idx not in b0_idx_for_bvec]
     
     work_bvec_reorg = join(sdir, 'bvecs_reorg')


### PR DESCRIPTION
At line 107 in writing reorganized bvecs, previous version could only handle the situation when there's only one b0 volume. This update should handle bvec and bval pairs that have unknown number of (multiple) b0 volumes.